### PR TITLE
Feat/api sortby

### DIFF
--- a/app/dummy-data/articles_v2.js
+++ b/app/dummy-data/articles_v2.js
@@ -1,0 +1,247 @@
+const v2DummyArticles = {
+    "status": "ok",
+    "articles": [
+        {
+            "source": {
+                "id": null,
+                "name": "Salesforce.com"
+            },
+            "author": null,
+            "title": "Data Manager - Import Data",
+            "description": "Hello,<br><br>I am trying to import data to saleforce. I have done twice but when I checked the challenge. It still shows that &quot;All the contact records from the CSV file were not found in the Org.&quot;<br>The Recent Import Jobs shows both of my import&#…",
+            "url": "https://success.salesforce.com/answers?id=9063A000000lCJhQAM",
+            "urlToImage": null,
+            "publishedAt": "2017-11-15T22:33:06Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Sap.com"
+            },
+            "author": "Paul Taylor",
+            "title": "Data, Data Everywhere舰Drowning in Data",
+            "description": "In the ‘Rime of the Ancient Mariner,’ written in the late 18th century by Samuel Taylor Coleridge, an old and becalmed sailor, complains that there is “water, water every where, nor any (but not a)",
+            "url": "https://blogs.sap.com/2017/09/25/data-data-everywhere...drowning-in-data/",
+            "urlToImage": null,
+            "publishedAt": "2017-09-25T19:12:05Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Sap.com"
+            },
+            "author": "Paul Taylor",
+            "title": "Data, Data Everywhere",
+            "description": "Extracting value from big and enterprise data is being held back by complexity. In the “Rime of the Ancient Mariner,”’ written in the late 18th century by Samuel Taylor Coleridge, an ol…",
+            "url": "https://news.sap.com/data-data-everywhere/",
+            "urlToImage": "https://news.sap.com/wp-content/blogs.dir/1/files/273904_273904_l_srgb_s_gl_F.jpg",
+            "publishedAt": "2017-09-25T18:58:09Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Anroed.com"
+            },
+            "author": "noreply@blogger.com (chathu_ac)",
+            "title": "Data Recharge & Data Saver 4G",
+            "description": "Data Recharge & Data Saver 4G Databack Lifestyle VERSION/BUILD: 2.0.0.119 UPDATED: 31 October 2017 REQUIRES ANDROID: 4.1 and up FILE SIZE: 7.81 M Databack saves your 2G, 3G and 4G mobile data that you spend when using apps. Save upto 500MB mobile data every m…",
+            "url": "https://www.anroed.com/2017/10/data-recharge-data-saver-4g.html",
+            "urlToImage": null,
+            "publishedAt": "2017-11-01T09:34:00Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Hackernoon.com"
+            },
+            "author": "Mark Schindler",
+            "title": "“Data-driven” versus “data-informed”",
+            "description": "Evaluating semantics and the impact of each term for generating team buy-in",
+            "url": "https://hackernoon.com/data-driven-versus-data-informed-22d07e29cfbf",
+            "urlToImage": "https://cdn-images-1.medium.com/max/1200/1*gju3-XMLy4RL3ctpA3bvoQ.jpeg",
+            "publishedAt": "2017-10-31T21:29:10Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Tableau.com"
+            },
+            "author": "tableaucommunity@tableau.com",
+            "title": "Data Visualisation using Trello Data",
+            "description": "<!-- [DocumentBodyStart:cad6ee5f-fff5-43f9-9e4e-de796e5794bb] -->Has any one used Trello Data to create Visualisations in Tableau? If yes, How did you extract the data from Trello and How do you connect so that Tableau shows live Data? <!-- [DocumentBodyEnd:c…",
+            "url": "https://community.tableau.com/thread/252135",
+            "urlToImage": null,
+            "publishedAt": "2017-11-10T05:44:33Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Computable.nl"
+            },
+            "author": null,
+            "title": "Data Warehousing en Data Management",
+            "description": "Cursus, Centraal in Nederland - Opleiding over Data Warehousing en Data Management",
+            "url": "https://www.computable.nl/event/agenda/6052390/1589222/data-warehousing-en-data-management.html",
+            "urlToImage": "https://www.computable.nl/media/cp_logo.jpg",
+            "publishedAt": "2017-11-09T08:00:00Z"
+        },
+        {
+            "source": {
+                "id": "google-news",
+                "name": "Google News"
+            },
+            "author": null,
+            "title": "Data Science Foundations: Data Mining",
+            "description": "",
+            "url": "http://feedproxy.google.com/~r/avaxhome/bojL/~3/3aAp3Mjjjj8/Data-Science-Foundations-Data-Mining-79876957.html",
+            "urlToImage": null,
+            "publishedAt": "2017-10-06T00:06:12Z"
+        },
+        {
+            "source": {
+                "id": "google-news",
+                "name": "Google News"
+            },
+            "author": null,
+            "title": "Data Divination: Big Data Strategies",
+            "description": "",
+            "url": "http://feedproxy.google.com/~r/avaxhome/wkEo/~3/brNAxWNVq4M/Data_Divination.html",
+            "urlToImage": null,
+            "publishedAt": "2017-10-22T07:18:17Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Computable.nl"
+            },
+            "author": null,
+            "title": "Data Warehousing en Data Management",
+            "description": "Seminar, Centraal in Nederland - Opleiding over Data Warehousing en Data Management",
+            "url": "https://www.computable.nl/event/agenda/6021800/1589222/data-warehousing-en-data-management.html",
+            "urlToImage": "https://www.computable.nl/media/cp_logo.jpg",
+            "publishedAt": "2017-10-06T07:00:00Z"
+        },
+        {
+            "source": {
+                "id": "google-news",
+                "name": "Google News"
+            },
+            "author": null,
+            "title": "Data Visualization for Data Analysts",
+            "description": "",
+            "url": "http://feedproxy.google.com/~r/avaxhome/bojL/~3/TzCXIPyu-S8/Data-Visualization-for-Data-Analysts-63064458.html",
+            "urlToImage": null,
+            "publishedAt": "2017-10-17T13:00:45Z"
+        },
+        {
+            "source": {
+                "id": "google-news",
+                "name": "Google News"
+            },
+            "author": null,
+            "title": "Data Divination: Big Data Strategies",
+            "description": "",
+            "url": "http://feedproxy.google.com/~r/avaxhome/bojL/~3/brNAxWNVq4M/Data_Divination.html",
+            "urlToImage": null,
+            "publishedAt": "2017-10-22T07:18:17Z"
+        },
+        {
+            "source": {
+                "id": "google-news",
+                "name": "Google News"
+            },
+            "author": null,
+            "title": "Data Mining and Big Data",
+            "description": "",
+            "url": "http://feedproxy.google.com/~r/avaxhome/bojL/~3/MSILWTQ14t0/331961844Xe.html",
+            "urlToImage": null,
+            "publishedAt": "2017-10-31T17:34:01Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Deviantart.com"
+            },
+            "author": null,
+            "title": "Data",
+            "description": "Datascrap the sharkdog~",
+            "url": "https://spiterising.deviantart.com/art/Data-714290259",
+            "urlToImage": "https://img00.deviantart.net/c382/i/2017/313/4/7/data_by_spiterising-dbt9pw3.jpg",
+            "publishedAt": "2017-11-10T02:07:29Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Deviantart.com"
+            },
+            "author": null,
+            "title": "Data",
+            "description": "",
+            "url": "https://hansdoddema.deviantart.com/art/Data-715196338",
+            "urlToImage": "https://orig00.deviantart.net/ba92/f/2017/319/f/7/data_by_hansdoddema-dbtt50y.png",
+            "publishedAt": "2017-11-15T11:20:51Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Dribbble.com"
+            },
+            "author": "zhaodaya",
+            "title": "Data",
+            "description": "View on Dribbble",
+            "url": "https://dribbble.com/shots/3934936-Data",
+            "urlToImage": "https://cdn.dribbble.com/users/471183/screenshots/3934936/data.png",
+            "publishedAt": "2017-11-09T09:17:54Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Www.gov.uk"
+            },
+            "author": null,
+            "title": "Transparency data: Condition Spend Data Collection (CSDC): Data Collection Report",
+            "description": "The CSDC report summarises findings from a review of Responsible Bodies’ use of the School Condition Allocation (SCA) during the 2015 to 2016 financial year.",
+            "url": "https://www.gov.uk/government/publications/condition-spend-data-collection-csdc-data-collection-report",
+            "urlToImage": "https://assets.publishing.service.gov.uk/static/opengraph-image-a1f7d89ffd0782738b1aeb0da37842d8bd0addbd724b8e58c3edbc7287cc11de.png",
+            "publishedAt": "2017-10-12T17:10:35Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Glassdoor.com"
+            },
+            "author": null,
+            "title": "Amazon DATA ASSOCIATE, ALEXA DATA SERVICES says \"Data associate ADS\"",
+            "description": "From Amazon DATA ASSOCIATE, ALEXA DATA SERVICES(Current Employee)&dash; Rating 5 out of 5 — Sun, 29 Oct 2017 Pros awesome work.. meet your targets and it's more than enough. NO tensions. No need to be under someone. OT pay is really good. Cons recent changes …",
+            "url": "https://www.glassdoor.com/Reviews/Employee-Review-Amazon-RVW17622905.htm",
+            "urlToImage": "https://media.glassdoor.com/lst2x/6036/amazon-office.jpg",
+            "publishedAt": "2017-10-30T06:49:43Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Deviantart.com"
+            },
+            "author": null,
+            "title": "Data",
+            "description": "Inktober. OC9 character. Data is the perfect cyborg. He must keep it a secret since he escaped from a lab who kept him a prisioner.",
+            "url": "https://tomiko2011.deviantart.com/art/Data-707625084",
+            "urlToImage": "https://st.deviantart.net/misc/noentrythumb-200.png",
+            "publishedAt": "2017-10-02T22:53:04Z"
+        },
+        {
+            "source": {
+                "id": null,
+                "name": "Dribbble.com"
+            },
+            "author": "Loic /// Likidea",
+            "title": "Data",
+            "description": "Check out my new reel : \nhttps://vimeo.com/235501588 \nThanks for watching!",
+            "url": "https://dribbble.com/shots/3834953-Data",
+            "urlToImage": "https://cdn.dribbble.com/users/437627/screenshots/3834953/reel_likidea_2_13.gif",
+            "publishedAt": "2017-09-27T08:24:29Z"
+        }
+    ]
+};
+
+export default v2DummyArticles;

--- a/app/dummy-data/sources_v2.js
+++ b/app/dummy-data/sources_v2.js
@@ -1,0 +1,1213 @@
+const v2DummySources = {
+    "status": "ok",
+    "sources": [
+        {
+            "id": "abc-news",
+            "name": "ABC News",
+            "description": "Your trusted source for breaking news, analysis, exclusive interviews, headlines, and videos at ABCNews.com.",
+            "url": "http://abcnews.go.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "abc-news-au",
+            "name": "ABC News (AU)",
+            "description": "Australia's most trusted source of local, national and world news. Comprehensive, independent, in-depth analysis, the latest business, sport, weather and more.",
+            "url": "http://www.abc.net.au/news",
+            "category": "general",
+            "language": "en",
+            "country": "au"
+        },
+        {
+            "id": "aftenposten",
+            "name": "Aftenposten",
+            "description": "Norges ledende nettavis med alltid oppdaterte nyheter innenfor innenriks, utenriks, sport og kultur.",
+            "url": "https://www.aftenposten.no",
+            "category": "general",
+            "language": "no",
+            "country": "no"
+        },
+        {
+            "id": "al-jazeera-english",
+            "name": "Al Jazeera English",
+            "description": "News, analysis from the Middle East and worldwide, multimedia and interactives, opinions, documentaries, podcasts, long reads and broadcast schedule.",
+            "url": "http://www.aljazeera.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "ansa",
+            "name": "ANSA.it",
+            "description": "Agenzia ANSA: ultime notizie, foto, video e approfondimenti su: cronaca, politica, economia, regioni, mondo, sport, calcio, cultura e tecnologia.",
+            "url": "http://www.ansa.it",
+            "category": "general",
+            "language": "it",
+            "country": "it"
+        },
+        {
+            "id": "argaam",
+            "name": "Argaam",
+            "description": "ارقام موقع متخصص في متابعة سوق الأسهم السعودي تداول - تاسي - مع تغطيه معمقة لشركات واسعار ومنتجات البتروكيماويات , تقارير مالية الاكتتابات الجديده ",
+            "url": "http://www.argaam.com",
+            "category": "business",
+            "language": "ar",
+            "country": "sa"
+        },
+        {
+            "id": "ars-technica",
+            "name": "Ars Technica",
+            "description": "The PC enthusiast's resource. Power users and the tools they love, without computing religion.",
+            "url": "http://arstechnica.com",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "ary-news",
+            "name": "Ary News",
+            "description": "ARY News is a Pakistani news channel committed to bring you up-to-the minute Pakistan news and featured stories from around Pakistan and all over the world.",
+            "url": "https://arynews.tv/ud/",
+            "category": "general",
+            "language": "ud",
+            "country": "pk"
+        },
+        {
+            "id": "associated-press",
+            "name": "Associated Press",
+            "description": "The AP delivers in-depth coverage on the international, politics, lifestyle, business, and entertainment news.",
+            "url": "https://apnews.com/",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "australian-financial-review",
+            "name": "Australian Financial Review",
+            "description": "The Australian Financial Review reports the latest news from business, finance, investment and politics, updated in real time. It has a reputation for independent, award-winning journalism and is essential reading for the business and investor community.",
+            "url": "http://www.afr.com",
+            "category": "business",
+            "language": "en",
+            "country": "au"
+        },
+        {
+            "id": "axios",
+            "name": "Axios",
+            "description": "Axios are a new media company delivering vital, trustworthy news and analysis in the most efficient, illuminating and shareable ways possible.",
+            "url": "https://www.axios.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "bbc-news",
+            "name": "BBC News",
+            "description": "Use BBC News for up-to-the-minute news, breaking news, video, audio and feature stories. BBC News provides trusted World and UK news as well as local and regional perspectives. Also entertainment, business, science, technology and health news.",
+            "url": "http://www.bbc.co.uk/news",
+            "category": "general",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "bbc-sport",
+            "name": "BBC Sport",
+            "description": "The home of BBC Sport online. Includes live sports coverage, breaking news, results, video, audio and analysis on Football, F1, Cricket, Rugby Union, Rugby League, Golf, Tennis and all the main world sports, plus major events such as the Olympic Games.",
+            "url": "http://www.bbc.co.uk/sport",
+            "category": "sport",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "bild",
+            "name": "Bild",
+            "description": "Die Seite 1 für aktuelle Nachrichten und Themen, Bilder und Videos aus den Bereichen News, Wirtschaft, Politik, Show, Sport, und Promis.",
+            "url": "http://www.bild.de",
+            "category": "general",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "blasting-news-br",
+            "name": "Blasting News (BR)",
+            "description": "Descubra a seção brasileira da Blasting News, a primeira revista feita pelo  público, com notícias globais e vídeos independentes. Junte-se a nós e torne- se um repórter.",
+            "url": "http://br.blastingnews.com",
+            "category": "general",
+            "language": "pt",
+            "country": "br"
+        },
+        {
+            "id": "bleacher-report",
+            "name": "Bleacher Report",
+            "description": "Sports journalists and bloggers covering NFL, MLB, NBA, NHL, MMA, college football and basketball, NASCAR, fantasy sports and more. News, photos, mock drafts, game scores, player profiles and more!",
+            "url": "http://www.bleacherreport.com",
+            "category": "sport",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "bloomberg",
+            "name": "Bloomberg",
+            "description": "Bloomberg delivers business and markets news, data, analysis, and video to the world, featuring stories from Businessweek and Bloomberg News.",
+            "url": "http://www.bloomberg.com",
+            "category": "business",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "breitbart-news",
+            "name": "Breitbart News",
+            "description": "Syndicated news and opinion website providing continuously updated headlines to top news and analysis sources.",
+            "url": "http://www.breitbart.com",
+            "category": "politics",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "business-insider",
+            "name": "Business Insider",
+            "description": "Business Insider is a fast-growing business site with deep financial, media, tech, and other industry verticals. Launched in 2007, the site is now the largest business news site on the web.",
+            "url": "http://www.businessinsider.com",
+            "category": "business",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "business-insider-uk",
+            "name": "Business Insider (UK)",
+            "description": "Business Insider is a fast-growing business site with deep financial, media, tech, and other industry verticals. Launched in 2007, the site is now the largest business news site on the web.",
+            "url": "http://uk.businessinsider.com",
+            "category": "business",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "buzzfeed",
+            "name": "Buzzfeed",
+            "description": "BuzzFeed is a cross-platform, global network for news and entertainment that generates seven billion views each month.",
+            "url": "https://www.buzzfeed.com",
+            "category": "entertainment",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "cbc-news",
+            "name": "CBC News",
+            "description": "CBC News is the division of the Canadian Broadcasting Corporation responsible for the news gathering and production of news programs on the corporation's English-language operations, namely CBC Television, CBC Radio, CBC News Network, and CBC.ca.",
+            "url": "http://www.cbc.ca/news",
+            "category": "general",
+            "language": "en",
+            "country": "ca"
+        },
+        {
+            "id": "cbs-news",
+            "name": "CBS News",
+            "description": "CBS News: dedicated to providing the best in journalism under standards it pioneered at the dawn of radio and television and continue in the digital age.",
+            "url": "http://www.cbsnews.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "cnbc",
+            "name": "CNBC",
+            "description": "Get latest business news on stock markets, financial & earnings on CNBC. View world markets streaming charts & video; check stock tickers and quotes.",
+            "url": "http://www.cnbc.com",
+            "category": "business",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "cnn",
+            "name": "CNN",
+            "description": "View the latest news and breaking news today for U.S., world, weather, entertainment, politics and health at CNN",
+            "url": "http://us.cnn.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "cnn-es",
+            "name": "CNN Spanish",
+            "description": "Lee las últimas noticias e información sobre Latinoamérica, Estados Unidos, mundo, entretenimiento, política, salud, tecnología y deportes en CNNEspañol.com.",
+            "url": "http://cnnespanol.cnn.com/",
+            "category": "general",
+            "language": "es",
+            "country": "us"
+        },
+        {
+            "id": "crypto-coins-news",
+            "name": "Crypto Coins News",
+            "description": "Providing breaking cryptocurrency news - focusing on Bitcoin, Ethereum, ICOs, blockchain technology, and smart contracts.",
+            "url": "https://www.cryptocoinsnews.com",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "daily-mail",
+            "name": "Daily Mail",
+            "description": "All the latest news, sport, showbiz, science and health stories from around the world from the Daily Mail and Mail on Sunday newspapers.",
+            "url": "http://www.dailymail.co.uk/home/index.html",
+            "category": "entertainment",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "der-tagesspiegel",
+            "name": "Der Tagesspiegel",
+            "description": "Nachrichten, News und neueste Meldungen aus dem Inland und dem Ausland - aktuell präsentiert von tagesspiegel.de.",
+            "url": "http://www.tagesspiegel.de",
+            "category": "general",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "die-zeit",
+            "name": "Die Zeit",
+            "description": "Aktuelle Nachrichten, Kommentare, Analysen und Hintergrundberichte aus Politik, Wirtschaft, Gesellschaft, Wissen, Kultur und Sport lesen Sie auf ZEIT ONLINE.",
+            "url": "http://www.zeit.de/index",
+            "category": "business",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "el-mundo",
+            "name": "El Mundo",
+            "description": "Noticias, actualidad, álbumes, debates, sociedad, servicios, entretenimiento y última hora en España y el mundo.",
+            "url": "http://www.elmundo.es",
+            "category": "general",
+            "language": "es",
+            "country": "es"
+        },
+        {
+            "id": "engadget",
+            "name": "Engadget",
+            "description": "Engadget is a web magazine with obsessive daily coverage of everything new in gadgets and consumer electronics.",
+            "url": "https://www.engadget.com",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "entertainment-weekly",
+            "name": "Entertainment Weekly",
+            "description": "Online version of the print magazine includes entertainment news, interviews, reviews of music, film, TV and books, and a special area for magazine subscribers.",
+            "url": "http://www.ew.com",
+            "category": "entertainment",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "espn",
+            "name": "ESPN",
+            "description": "ESPN has up-to-the-minute sports news coverage, scores, highlights and commentary for NFL, MLB, NBA, College Football, NCAA Basketball and more.",
+            "url": "http://espn.go.com",
+            "category": "sport",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "espn-cric-info",
+            "name": "ESPN Cric Info",
+            "description": "ESPN Cricinfo provides the most comprehensive cricket coverage available including live ball-by-ball commentary, news, unparalleled statistics, quality editorial comment and analysis.",
+            "url": "http://www.espncricinfo.com/",
+            "category": "sport",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "financial-post",
+            "name": "Financial Post",
+            "description": "Find the latest happenings in the Canadian Financial Sector and stay up to date with changing trends in Business Markets. Read trading and investing advice from professionals.",
+            "url": "http://business.financialpost.com",
+            "category": "business",
+            "language": "en",
+            "country": "ca"
+        },
+        {
+            "id": "financial-times",
+            "name": "Financial Times",
+            "description": "The latest UK and international business, finance, economic and political news, comment and analysis from the Financial Times on FT.com.",
+            "url": "http://www.ft.com/home/uk",
+            "category": "business",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "focus",
+            "name": "Focus",
+            "description": "Minutenaktuelle Nachrichten und Service-Informationen von Deutschlands modernem Nachrichtenmagazin.",
+            "url": "http://www.focus.de",
+            "category": "general",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "football-italia",
+            "name": "Football Italia",
+            "description": "Italian football news, analysis, fixtures and results for the latest from Serie A, Serie B and the Azzurri.",
+            "url": "http://www.football-italia.net",
+            "category": "sport",
+            "language": "en",
+            "country": "it"
+        },
+        {
+            "id": "fortune",
+            "name": "Fortune",
+            "description": "Fortune 500 Daily and Breaking Business News",
+            "url": "http://fortune.com",
+            "category": "business",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "four-four-two",
+            "name": "FourFourTwo",
+            "description": "The latest football news, in-depth features, tactical and statistical analysis from FourFourTwo, the UK&#039;s favourite football monthly.",
+            "url": "http://www.fourfourtwo.com/news",
+            "category": "sport",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "fox-news",
+            "name": "Fox News",
+            "description": "Breaking News, Latest News and Current News from FOXNews.com. Breaking news and video. Latest Current News: U.S., World, Entertainment, Health, Business, Technology, Politics, Sports.",
+            "url": "http://www.foxnews.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "fox-sports",
+            "name": "Fox Sports",
+            "description": "Find live scores, player and team news, videos, rumors, stats, standings, schedules and fantasy games on FOX Sports.",
+            "url": "http://www.foxsports.com",
+            "category": "sport",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "globo",
+            "name": "Globo",
+            "description": "Só na globo.com você encontra tudo sobre o conteúdo e marcas do Grupo Globo. O melhor acervo de vídeos online sobre entretenimento, esportes e jornalismo do Brasil.",
+            "url": "http://www.globo.com/",
+            "category": "general",
+            "language": "pt",
+            "country": "br"
+        },
+        {
+            "id": "google-news",
+            "name": "Google News",
+            "description": "Comprehensive, up-to-date news coverage, aggregated from sources all over the world by Google News.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "google-news-ar",
+            "name": "Google News (Argentina)",
+            "description": "Completa cobertura actualizada de noticias agregadas a partir de fuentes de todo el mundo por Google Noticias.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "es",
+            "country": "ar"
+        },
+        {
+            "id": "google-news-au",
+            "name": "Google News (Australia)",
+            "description": "Comprehensive, up-to-date Australia news coverage, aggregated from sources all over the world by Google News.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "en",
+            "country": "au"
+        },
+        {
+            "id": "google-news-br",
+            "name": "Google News (Brasil)",
+            "description": "Cobertura jornalística abrangente e atualizada, agregada de fontes do mundo inteiro pelo Google Notícias.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "pt",
+            "country": "br"
+        },
+        {
+            "id": "google-news-ca",
+            "name": "Google News (Canada)",
+            "description": "Comprehensive, up-to-date Canada news coverage, aggregated from sources all over the world by Google News.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "en",
+            "country": "ca"
+        },
+        {
+            "id": "google-news-fr",
+            "name": "Google News (France)",
+            "description": "Informations complètes et à jour, compilées par Google Actualités à partir de sources d&#39;actualités du monde entier.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "fr",
+            "country": "fr"
+        },
+        {
+            "id": "google-news-in",
+            "name": "Google News (India)",
+            "description": "Comprehensive, up-to-date India news coverage, aggregated from sources all over the world by Google News.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "en",
+            "country": "in"
+        },
+        {
+            "id": "google-news-is",
+            "name": "Google News (Israel)",
+            "description": "כיסוי מקיף ועדכני של חדשות שהצטברו ממקורות בכל העולם על ידי &#39;חדשות Google&#39;.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "he",
+            "country": "is"
+        },
+        {
+            "id": "google-news-it",
+            "name": "Google News (Italy)",
+            "description": "Copertura giornalistica completa e aggiornata ottenuta combinando fonti di notizie in tutto il mondo attraverso Google News.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "it",
+            "country": "it"
+        },
+        {
+            "id": "google-news-ru",
+            "name": "Google News (Russia)",
+            "description": "Исчерпывающая и актуальная информация, собранная службой &quot;Новости Google&quot; со всего света.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "ru",
+            "country": "ru"
+        },
+        {
+            "id": "google-news-sa",
+            "name": "Google News (Saudi Arabia)",
+            "description": "تغطية شاملة ومتجددة للأخبار، تم جمعها من مصادر أخبار من جميع أنحاء العالم بواسطة أخبار Google.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "ar",
+            "country": "sa"
+        },
+        {
+            "id": "google-news-uk",
+            "name": "Google News (UK)",
+            "description": "Comprehensive, up-to-date UK news coverage, aggregated from sources all over the world by Google News.",
+            "url": "https://news.google.com",
+            "category": "general",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "goteborgs-posten",
+            "name": "Göteborgs-Posten",
+            "description": "Göteborgs-Posten, abbreviated GP, is a major Swedish language daily newspaper published in Gothenburg, Sweden.",
+            "url": "http://www.gp.se",
+            "category": "general",
+            "language": "sv",
+            "country": "sv"
+        },
+        {
+            "id": "gruenderszene",
+            "name": "Gruenderszene",
+            "description": "Online-Magazin für Startups und die digitale Wirtschaft. News und Hintergründe zu Investment, VC und Gründungen.",
+            "url": "http://www.gruenderszene.de",
+            "category": "technology",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "hacker-news",
+            "name": "Hacker News",
+            "description": "Hacker News is a social news website focusing on computer science and entrepreneurship. It is run by Paul Graham's investment fund and startup incubator, Y Combinator. In general, content that can be submitted is defined as \"anything that gratifies one's intellectual curiosity\".",
+            "url": "https://news.ycombinator.com",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "handelsblatt",
+            "name": "Handelsblatt",
+            "description": "Auf Handelsblatt lesen sie Nachrichten über Unternehmen, Finanzen, Politik und Technik. Verwalten Sie Ihre Finanzanlagen mit Hilfe unserer Börsenkurse.",
+            "url": "http://www.handelsblatt.com",
+            "category": "business",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "ign",
+            "name": "IGN",
+            "description": "IGN is your site for Xbox One, PS4, PC, Wii-U, Xbox 360, PS3, Wii, 3DS, PS Vita and iPhone games with expert reviews, news, previews, trailers, cheat codes, wiki guides and walkthroughs.",
+            "url": "http://www.ign.com",
+            "category": "gaming",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "il-sole-24-ore",
+            "name": "Il Sole 24 Ore",
+            "description": "Notizie di economia, cronaca italiana ed estera, quotazioni borsa in tempo reale e di finanza, norme e tributi, fondi e obbligazioni, mutui, prestiti e lavoro a cura de Il Sole 24 Ore.",
+            "url": "http://www.ilsole24ore.com",
+            "category": "business",
+            "language": "it",
+            "country": "it"
+        },
+        {
+            "id": "independent",
+            "name": "Independent",
+            "description": "National morning quality (tabloid) includes free online access to news and supplements. Insight by Robert Fisk and various other columnists.",
+            "url": "http://www.independent.co.uk",
+            "category": "general",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "infobae",
+            "name": "Infobae",
+            "description": "Noticias de Argentina y del mundo en tiempo real. Información, videos y fotos sobre los hechos más relevantes y sus protagonistas. Léelo antes en infobae.",
+            "url": "http://www.infobae.com/?noredirect",
+            "category": "general",
+            "language": "es",
+            "country": "ar"
+        },
+        {
+            "id": "info-money",
+            "name": "InfoMoney",
+            "description": "No InfoMoney você encontra tudo o que precisa sobre dinheiro. Ações, investimentos, bolsas de valores e muito mais. Aqui você encontra informação que vale dinheiro!",
+            "url": "http://www.infomoney.com.br",
+            "category": "business",
+            "language": "pt",
+            "country": "br"
+        },
+        {
+            "id": "la-gaceta",
+            "name": "La Gaceta",
+            "description": "El diario de Tucumán, noticias 24 horas online - San Miguel de Tucumán - Argentina - Ultimo momento - Ultimas noticias.",
+            "url": "http://www.lagaceta.com.ar",
+            "category": "general",
+            "language": "es",
+            "country": "ar"
+        },
+        {
+            "id": "la-nacion",
+            "name": "La Nacion",
+            "description": "Información confiable en Internet. Noticias de Argentina y del mundo - ¡Informate ya!",
+            "url": "http://www.lanacion.com.ar",
+            "category": "politics",
+            "language": "es",
+            "country": "ar"
+        },
+        {
+            "id": "la-repubblica",
+            "name": "La Repubblica",
+            "description": "Breaking News, Latest News and Current News from FOXNews.com. Breaking news and video. Latest Current News: U.S., World, Entertainment, Health, Business, Technology, Politics, Sports.",
+            "url": "http://www.repubblica.it",
+            "category": "general",
+            "language": "it",
+            "country": "it"
+        },
+        {
+            "id": "le-monde",
+            "name": "Le Monde",
+            "description": "Les articles du journal et toute l'actualit&eacute; en continu : International, France, Soci&eacute;t&eacute;, Economie, Culture, Environnement, Blogs ...",
+            "url": "http://www.lemonde.fr",
+            "category": "general",
+            "language": "fr",
+            "country": "fr"
+        },
+        {
+            "id": "lenta",
+            "name": "Lenta",
+            "description": "Новости, статьи, фотографии, видео. Семь дней в неделю, 24 часа в сутки.",
+            "url": "https://lenta.ru",
+            "category": "general",
+            "language": "ru",
+            "country": "ru"
+        },
+        {
+            "id": "lequipe",
+            "name": "L'equipe",
+            "description": "Le sport en direct sur L'EQUIPE.fr. Les informations, résultats et classements de tous les sports. Directs commentés, images et vidéos à regarder et à partager !",
+            "url": "https://www.lequipe.fr",
+            "category": "sport",
+            "language": "fr",
+            "country": "fr"
+        },
+        {
+            "id": "les-echos",
+            "name": "Les Echos",
+            "description": "Toute l'actualité économique, financière et boursière française et internationale sur Les Echos.fr",
+            "url": "https://www.lesechos.fr",
+            "category": "business",
+            "language": "fr",
+            "country": "fr"
+        },
+        {
+            "id": "liberation",
+            "name": "Libération",
+            "description": "Toute l'actualité en direct - photos et vidéos avec Libération",
+            "url": "http://www.liberation.fr",
+            "category": "general",
+            "language": "fr",
+            "country": "fr"
+        },
+        {
+            "id": "marca",
+            "name": "Marca",
+            "description": "La mejor información deportiva en castellano actualizada minuto a minuto en noticias, vídeos, fotos, retransmisiones y resultados en directo.",
+            "url": "http://www.marca.com",
+            "category": "sport",
+            "language": "es",
+            "country": "es"
+        },
+        {
+            "id": "mashable",
+            "name": "Mashable",
+            "description": "Mashable is a global, multi-platform media and entertainment company.",
+            "url": "http://mashable.com",
+            "category": "entertainment",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "medical-news-today",
+            "name": "Medical News Today",
+            "description": "Medical news and health news headlines posted throughout the day, every day.",
+            "url": "http://www.medicalnewstoday.com",
+            "category": "health-and-medical",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "metro",
+            "name": "Metro",
+            "description": "News, Sport, Showbiz, Celebrities from Metro - a free British newspaper.",
+            "url": "http://metro.co.uk",
+            "category": "general",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "mirror",
+            "name": "Mirror",
+            "description": "All the latest news, sport and celebrity gossip at Mirror.co.uk. Get all the big headlines, pictures, analysis, opinion and video on the stories that matter to you.",
+            "url": "http://www.mirror.co.uk/",
+            "category": "general",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "msnbc",
+            "name": "MSNBC",
+            "description": "Breaking news and in-depth analysis of the headlines, as well as commentary and informed perspectives from The Rachel Maddow Show, Morning Joe & more.",
+            "url": "http://www.msnbc.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "mtv-news",
+            "name": "MTV News",
+            "description": "The ultimate news source for music, celebrity, entertainment, movies, and current events on the web. It's pop culture on steroids.",
+            "url": "http://www.mtv.com/news",
+            "category": "music",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "mtv-news-uk",
+            "name": "MTV News (UK)",
+            "description": "All the latest celebrity news, gossip, exclusive interviews and pictures from the world of music and entertainment.",
+            "url": "http://www.mtv.co.uk/news",
+            "category": "music",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "national-geographic",
+            "name": "National Geographic",
+            "description": "Reporting our world daily: original nature and science news from National Geographic.",
+            "url": "http://news.nationalgeographic.com",
+            "category": "science-and-nature",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "nbc-news",
+            "name": "NBC News",
+            "description": "Breaking news, videos, and the latest top stories in world news, business, politics, health and pop culture.",
+            "url": "http://www.nbcnews.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "news24",
+            "name": "News24",
+            "description": "South Africa's premier news source, provides breaking news on national, world, Africa, sport, entertainment, technology and more.",
+            "url": "http://www.news24.com",
+            "category": "general",
+            "language": "en",
+            "country": "za"
+        },
+        {
+            "id": "new-scientist",
+            "name": "New Scientist",
+            "description": "Breaking science and technology news from around the world. Exclusive stories and expert analysis on space, technology, health, physics, life and Earth.",
+            "url": "https://www.newscientist.com/section/news",
+            "category": "science-and-nature",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "news-com-au",
+            "name": "News.com.au",
+            "description": "We say what people are thinking and cover the issues that get people talking balancing Australian and global moments — from politics to pop culture.",
+            "url": "http://www.news.com.au",
+            "category": "general",
+            "language": "en",
+            "country": "au"
+        },
+        {
+            "id": "newsweek",
+            "name": "Newsweek",
+            "description": "Newsweek provides in-depth analysis, news and opinion about international issues, technology, business, culture and politics.",
+            "url": "http://www.newsweek.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "new-york-magazine",
+            "name": "New York Magazine",
+            "description": "NYMAG and New York magazine cover the new, the undiscovered, the next in politics, culture, food, fashion, and behavior nationally, through a New York lens.",
+            "url": "http://nymag.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "next-big-future",
+            "name": "Next Big Future",
+            "description": "Coverage of science and technology that have the potential for disruption, and analysis of plans, policies, and technology that enable radical improvement.",
+            "url": "https://www.nextbigfuture.com",
+            "category": "science-and-nature",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "nfl-news",
+            "name": "NFL News",
+            "description": "The official source for NFL news, schedules, stats, scores and more.",
+            "url": "http://www.nfl.com/news",
+            "category": "sport",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "nhl-news",
+            "name": "NHL News",
+            "description": "The most up-to-date breaking hockey news from the official source including interviews, rumors, statistics and schedules.",
+            "url": "https://www.nhl.com/news",
+            "category": "sport",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "nrk",
+            "name": "NRK",
+            "description": "NRK er Norges største tilbud på nett: nyheter fra Norge og verden, lokalnyheter, radio- og tv-program, podcast, vær, helse-, kultur-, underholdning-, humor- og debattstoff.",
+            "url": "https://www.nrk.no",
+            "category": "general",
+            "language": "no",
+            "country": "no"
+        },
+        {
+            "id": "politico",
+            "name": "Politico",
+            "description": "Political news about Congress, the White House, campaigns, lobbyists and issues.",
+            "url": "https://www.politico.com",
+            "category": "politics",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "polygon",
+            "name": "Polygon",
+            "description": "Polygon is a gaming website in partnership with Vox Media. Our culture focused site covers games, their creators, the fans, trending stories and entertainment news.",
+            "url": "http://www.polygon.com",
+            "category": "gaming",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "rbc",
+            "name": "RBC",
+            "description": "Главные новости политики, экономики и бизнеса, комментарии аналитиков, финансовые данные с российских и мировых биржевых систем на сайте rbc.ru.",
+            "url": "http://www.rbc.ru",
+            "category": "general",
+            "language": "ru",
+            "country": "ru"
+        },
+        {
+            "id": "recode",
+            "name": "Recode",
+            "description": "Get the latest independent tech news, reviews and analysis from Recode with the most informed and respected journalists in technology and media.",
+            "url": "http://www.recode.net",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "reddit-r-all",
+            "name": "Reddit /r/all",
+            "description": "Reddit is an entertainment, social news networking service, and news website. Reddit's registered community members can submit content, such as text posts or direct links.",
+            "url": "https://www.reddit.com/r/all",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "reuters",
+            "name": "Reuters",
+            "description": "Reuters.com brings you the latest news from around the world, covering breaking news in business, politics, entertainment, technology, video and pictures.",
+            "url": "http://www.reuters.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "rt",
+            "name": "RT",
+            "description": "Актуальная картина дня на RT: круглосуточное ежедневное обновление новостей политики, бизнеса, финансов, спорта, науки, культуры. Онлайн-репортажи с места событий. Комментарии экспертов, актуальные интервью, фото и видео репортажи.",
+            "url": "https://russian.rt.com",
+            "category": "general",
+            "language": "ru",
+            "country": "ru"
+        },
+        {
+            "id": "rte",
+            "name": "RTE",
+            "description": "Get all of the latest breaking local and international news stories as they happen, with up to the minute updates and analysis, from Ireland's National Broadcaster.",
+            "url": "https://www.rte.ie/news",
+            "category": "general",
+            "language": "en",
+            "country": "ie"
+        },
+        {
+            "id": "rtl-nieuws",
+            "name": "RTL Nieuws",
+            "description": "Volg het nieuws terwijl het gebeurt. RTL Nieuws informeert haar lezers op een onafhankelijke, boeiende en toegankelijke wijze over belangrijke ontwikkelingen in eigen land en de rest van de wereld.",
+            "url": "https://www.rtlnieuws.nl/",
+            "category": "general",
+            "language": "nl",
+            "country": "nl"
+        },
+        {
+            "id": "sabq",
+            "name": "SABQ",
+            "description": "صحيفة الكترونية سعودية هدفها السبق في نقل الحدث بمهنية ومصداقية خدمة للوطن والمواطن.",
+            "url": "https://sabq.org",
+            "category": "general",
+            "language": "ar",
+            "country": "sa"
+        },
+        {
+            "id": "spiegel-online",
+            "name": "Spiegel Online",
+            "description": "Deutschlands führende Nachrichtenseite. Alles Wichtige aus Politik, Wirtschaft, Sport, Kultur, Wissenschaft, Technik und mehr.",
+            "url": "http://www.spiegel.de",
+            "category": "general",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "svenska-dagbladet",
+            "name": "Svenska Dagbladet",
+            "description": "Sveriges ledande mediesajt - SvD.se. Svenska Dagbladets nyhetssajt låter läsarna ta plats och fördjupar nyheterna.",
+            "url": "https://www.svd.se",
+            "category": "general",
+            "language": "sv",
+            "country": "sv"
+        },
+        {
+            "id": "t3n",
+            "name": "T3n",
+            "description": "Das Online-Magazin bietet Artikel zu den Themen E-Business, Social Media, Startups und Webdesign.",
+            "url": "http://t3n.de",
+            "category": "technology",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "talksport",
+            "name": "TalkSport",
+            "description": "Tune in to the world's biggest sports radio station - Live Premier League football coverage, breaking sports news, transfer rumours &amp; exclusive interviews.",
+            "url": "http://talksport.com",
+            "category": "sport",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "techcrunch",
+            "name": "TechCrunch",
+            "description": "TechCrunch is a leading technology media property, dedicated to obsessively profiling startups, reviewing new Internet products, and breaking tech news.",
+            "url": "https://techcrunch.com",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "techcrunch-cn",
+            "name": "TechCrunch (CN)",
+            "description": "TechCrunch is a leading technology media property, dedicated to obsessively profiling startups, reviewing new Internet products, and breaking tech news.",
+            "url": "https://techcrunch.cn",
+            "category": "technology",
+            "language": "cn",
+            "country": "cn"
+        },
+        {
+            "id": "techradar",
+            "name": "TechRadar",
+            "description": "The latest technology news and reviews, covering computing, home entertainment systems, gadgets and more.",
+            "url": "http://www.techradar.com",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "the-economist",
+            "name": "The Economist",
+            "description": "The Economist offers authoritative insight and opinion on international news, politics, business, finance, science, technology and the connections between them.",
+            "url": "http://www.economist.com",
+            "category": "business",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "the-globe-and-mail",
+            "name": "The Globe And Mail",
+            "description": "The Globe and Mail offers the most authoritative news in Canada, featuring national and international news.",
+            "url": "https://www.theglobeandmail.com",
+            "category": "general",
+            "language": "en",
+            "country": "ca"
+        },
+        {
+            "id": "the-guardian-au",
+            "name": "The Guardian (AU)",
+            "description": "Latest news, sport, comment, analysis and reviews from Guardian Australia",
+            "url": "https://www.theguardian.com/au",
+            "category": "general",
+            "language": "en",
+            "country": "au"
+        },
+        {
+            "id": "the-guardian-uk",
+            "name": "The Guardian (UK)",
+            "description": "Latest news, sport, business, comment, analysis and reviews from the Guardian, the world's leading liberal voice.",
+            "url": "https://www.theguardian.com/uk",
+            "category": "general",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "the-hill",
+            "name": "The Hill",
+            "description": "The Hill is a top US political website, read by the White House and more lawmakers than any other site -- vital for policy, politics and election campaigns.",
+            "url": "http://thehill.com",
+            "category": "politics",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "the-hindu",
+            "name": "The Hindu",
+            "description": "The Hindu. latest news, analysis, comment, in-depth coverage of politics, business, sport, environment, cinema and arts from India's national newspaper.",
+            "url": "http://www.thehindu.com",
+            "category": "general",
+            "language": "en",
+            "country": "in"
+        },
+        {
+            "id": "the-huffington-post",
+            "name": "The Huffington Post",
+            "description": "The Huffington Post is a politically liberal American online news aggregator and blog that has both localized and international editions founded by Arianna Huffington, Kenneth Lerer, Andrew Breitbart, and Jonah Peretti, featuring columnists.",
+            "url": "http://www.huffingtonpost.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "the-irish-times",
+            "name": "The Irish Times",
+            "description": "The Irish Times online. Latest news including sport, analysis, business, weather and more from the definitive brand of quality news in Ireland.",
+            "url": "https://www.irishtimes.com",
+            "category": "general",
+            "language": "en",
+            "country": "ie"
+        },
+        {
+            "id": "the-lad-bible",
+            "name": "The Lad Bible",
+            "description": "The LAD Bible is one of the largest community for guys aged 16-30 in the world. Send us your funniest pictures and videos!",
+            "url": "http://www.theladbible.com",
+            "category": "entertainment",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "the-new-york-times",
+            "name": "The New York Times",
+            "description": "The New York Times: Find breaking news, multimedia, reviews & opinion on Washington, business, sports, movies, travel, books, jobs, education, real estate, cars & more at nytimes.com.",
+            "url": "http://www.nytimes.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "the-next-web",
+            "name": "The Next Web",
+            "description": "The Next Web is one of the world’s largest online publications that delivers an international perspective on the latest news about Internet technology, business and culture.",
+            "url": "http://thenextweb.com",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "the-sport-bible",
+            "name": "The Sport Bible",
+            "description": "TheSPORTbible is one of the largest communities for sports fans across the world. Send us your sporting pictures and videos!",
+            "url": "http://www.thesportbible.com",
+            "category": "sport",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "the-telegraph",
+            "name": "The Telegraph",
+            "description": "Latest news, business, sport, comment, lifestyle and culture from the Daily Telegraph and Sunday Telegraph newspapers and video from Telegraph TV.",
+            "url": "http://www.telegraph.co.uk",
+            "category": "general",
+            "language": "en",
+            "country": "gb"
+        },
+        {
+            "id": "the-times-of-india",
+            "name": "The Times of India",
+            "description": "Times of India brings the Latest News and Top Breaking headlines on Politics and Current Affairs in India and around the World, Sports, Business, Bollywood News and Entertainment, Science, Technology, Health and Fitness news, Cricket and opinions from leading columnists.",
+            "url": "http://timesofindia.indiatimes.com",
+            "category": "general",
+            "language": "en",
+            "country": "in"
+        },
+        {
+            "id": "the-verge",
+            "name": "The Verge",
+            "description": "The Verge covers the intersection of technology, science, art, and culture.",
+            "url": "http://www.theverge.com",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "the-wall-street-journal",
+            "name": "The Wall Street Journal",
+            "description": "WSJ online coverage of breaking news and current headlines from the US and around the world. Top stories, photos, videos, detailed analysis and in-depth reporting.",
+            "url": "http://www.wsj.com",
+            "category": "business",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "the-washington-post",
+            "name": "The Washington Post",
+            "description": "Breaking news and analysis on politics, business, world national news, entertainment more. In-depth DC, Virginia, Maryland news coverage including traffic, weather, crime, education, restaurant reviews and more.",
+            "url": "https://www.washingtonpost.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "time",
+            "name": "Time",
+            "description": "Breaking news and analysis from TIME.com. Politics, world news, photos, video, tech reviews, health, science and entertainment news.",
+            "url": "http://time.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "usa-today",
+            "name": "USA Today",
+            "description": "Get the latest national, international, and political news at USATODAY.com.",
+            "url": "http://www.usatoday.com/news",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "vice-news",
+            "name": "Vice News",
+            "description": "Vice News is Vice Media, Inc.'s current affairs channel, producing daily documentary essays and video through its website and YouTube channel. It promotes itself on its coverage of \"under - reported stories\".",
+            "url": "https://news.vice.com",
+            "category": "general",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "wired",
+            "name": "Wired",
+            "description": "Wired is a monthly American magazine, published in print and online editions, that focuses on how emerging technologies affect culture, the economy, and politics.",
+            "url": "https://www.wired.com",
+            "category": "technology",
+            "language": "en",
+            "country": "us"
+        },
+        {
+            "id": "wired-de",
+            "name": "Wired.de",
+            "description": "Wired reports on how emerging technologies affect culture, the economy and politics.",
+            "url": "https://www.wired.de",
+            "category": "technology",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "wirtschafts-woche",
+            "name": "Wirtschafts Woche",
+            "description": "Das Online-Portal des führenden Wirtschaftsmagazins in Deutschland. Das Entscheidende zu Unternehmen, Finanzen, Erfolg und Technik.",
+            "url": "http://www.wiwo.de",
+            "category": "business",
+            "language": "de",
+            "country": "de"
+        },
+        {
+            "id": "xinhua-net",
+            "name": "Xinhua Net",
+            "description": "中国主要重点新闻网站,依托新华社遍布全球的采编网络,记者遍布世界100多个国家和地区,地方频道分布全国31个省市自治区,每天24小时同时使用6种语言滚动发稿,权威、准确、及时播发国内外重要新闻和重大突发事件,受众覆盖200多个国家和地区,发展论坛是全球知名的中文论坛。",
+            "url": "http://xinhuanet.com/",
+            "category": "general",
+            "language": "cn",
+            "country": "cn"
+        },
+        {
+            "id": "ynet",
+            "name": "Ynet",
+            "description": "ynet דף הבית: אתר החדשות המוביל בישראל מבית ידיעות אחרונות. סיקור מלא של חדשות מישראל והעולם, ספורט, כלכלה, תרבות, אוכל, מדע וטבע, כל מה שקורה וכל מה שמעניין ב ynet.",
+            "url": "http://www.ynet.co.il",
+            "category": "general",
+            "language": "he",
+            "country": "is"
+        }
+    ]
+};
+
+export default v2DummySources;

--- a/app/server/app.js
+++ b/app/server/app.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import express from 'express';
-import searchArticles from './middleware/search';
+import searchBySource from './middleware/bySource';
 
 const app = express();
 
@@ -13,7 +13,7 @@ app.get('/', (request, response) => {
   response.sendFile(indexPath);
 });
 
-app.get('/articles', searchArticles, (request, response) => {
+app.get('/articles', searchBySource, (request, response) => {
   response.status(200);
 
   // sends back an array of articles for a single source

--- a/app/server/app.js
+++ b/app/server/app.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import express from 'express';
-import searchBySource from './middleware/bySource';
+import searchArticles from './middleware/bySource';
 
 const app = express();
 
@@ -13,7 +13,7 @@ app.get('/', (request, response) => {
   response.sendFile(indexPath);
 });
 
-app.get('/articles', searchBySource, (request, response) => {
+app.get('/articles', searchArticles, (request, response) => {
   response.status(200);
 
   // sends back an array of articles for a single source

--- a/app/server/middleware/bySource.js
+++ b/app/server/middleware/bySource.js
@@ -10,12 +10,7 @@ const searchArticles = (request, response, next) => {
   const search = `https://newsapi.org/v2/everything?apiKey=${process.env.NEWS_KEY}&source=${source}&sortBy=${sortBy}&q=${topic}`;
 
   apiHelper(search, (newsData) => {
-    const articles = newsData.articles.map((article) => {
-      const newArticle = article;
-      newArticle.source = source;
-      return newArticle;
-    });
-    request.articles = articles;
+    request.articles = newsData.articles;
     next();
   }, (err) => {
     console.log(err);

--- a/app/server/middleware/bySource.js
+++ b/app/server/middleware/bySource.js
@@ -1,13 +1,15 @@
-import getArticles from './search';
+import apiHelper from './search';
 
-const searchBySource = (request, response, next) => {
+const searchArticles = (request, response, next) => {
   // only searches a single source, rather than an
   // array of sources
-  const { source, sortBy } = request.query;
+  // need to see what that request will look like
+  // before we can search for multiple sources
+  const { source, sortBy, topic } = request.query;
 
-  const search = `https://newsapi.org/v1/articles?apiKey=${process.env.NEWS_KEY}&source=${source}&sortBy=${sortBy}`;
+  const search = `https://newsapi.org/v2/everything?apiKey=${process.env.NEWS_KEY}&source=${source}&sortBy=${sortBy}&q=${topic}`;
 
-  getArticles(search, (newsData) => {
+  apiHelper(search, (newsData) => {
     const articles = newsData.articles.map((article) => {
       const newArticle = article;
       newArticle.source = source;
@@ -21,4 +23,4 @@ const searchBySource = (request, response, next) => {
   });
 };
 
-export default searchBySource;
+export default searchArticles;

--- a/app/server/middleware/bySource.js
+++ b/app/server/middleware/bySource.js
@@ -1,14 +1,13 @@
-import getArticles from './search.js'
+import getArticles from './search';
 
 const searchBySource = (request, response, next) => {
   // only searches a single source, rather than an
   // array of sources
   const { source, sortBy } = request.query;
-  console.log(sortBy);
 
-  const search = `https://newsapi.org/v1/articles?apiKey=${process.env.NEWS_KEY}&source=${source}`;
+  const search = `https://newsapi.org/v1/articles?apiKey=${process.env.NEWS_KEY}&source=${source}&sortBy=${sortBy}`;
 
-  getArticles(search, sortBy, (newsData) => {
+  getArticles(search, (newsData) => {
     const articles = newsData.articles.map((article) => {
       const newArticle = article;
       newArticle.source = source;

--- a/app/server/middleware/bySource.js
+++ b/app/server/middleware/bySource.js
@@ -1,0 +1,25 @@
+import getArticles from './search.js'
+
+const searchBySource = (request, response, next) => {
+  // only searches a single source, rather than an
+  // array of sources
+  const { source, sortBy } = request.query;
+  console.log(sortBy);
+
+  const search = `https://newsapi.org/v1/articles?apiKey=${process.env.NEWS_KEY}&source=${source}`;
+
+  getArticles(search, sortBy, (newsData) => {
+    const articles = newsData.articles.map((article) => {
+      const newArticle = article;
+      newArticle.source = source;
+      return newArticle;
+    });
+    request.articles = articles;
+    next();
+  }, (err) => {
+    console.log(err);
+    response.status(500).send('Error--request can\'t be processed.');
+  });
+};
+
+export default searchBySource;

--- a/app/server/middleware/search.js
+++ b/app/server/middleware/search.js
@@ -3,8 +3,8 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const getArticles = (baseSearch, sortBy, successCallback, failureCallback) => {
-  axios.get(`${baseSearch}&sortBy=${sortBy}`)
+const getArticles = (search, successCallback, failureCallback) => {
+  axios.get(search)
     .then((newsResponse) => {
       successCallback(newsResponse.data);
     })

--- a/app/server/middleware/search.js
+++ b/app/server/middleware/search.js
@@ -13,26 +13,4 @@ const getArticles = (baseSearch, sortBy, successCallback, failureCallback) => {
     });
 };
 
-const searchArticles = (request, response, next) => {
-  // only searches a single source, rather than an
-  // array of sources
-  const { source, sortBy } = request.query;
-  console.log(sortBy);
-
-  const search = `https://newsapi.org/v1/articles?apiKey=${process.env.NEWS_KEY}&source=${source}`;
-
-  getArticles(search, sortBy, (newsData) => {
-    const articles = newsData.articles.map((article) => {
-      const newArticle = article;
-      newArticle.source = source;
-      return newArticle;
-    });
-    request.articles = articles;
-    next();
-  }, (err) => {
-    console.log(err);
-    response.status(500).send('Error--request can\'t be processed.');
-  });
-};
-
-export default searchArticles;
+export default getArticles;

--- a/app/server/middleware/search.js
+++ b/app/server/middleware/search.js
@@ -3,30 +3,36 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+const getArticles = (baseSearch, sortBy, successCallback, failureCallback) => {
+  axios.get(`${baseSearch}&sortBy=${sortBy}`)
+    .then((newsResponse) => {
+      successCallback(newsResponse.data);
+    })
+    .catch((err) => {
+      failureCallback(err);
+    });
+};
+
 const searchArticles = (request, response, next) => {
   // only searches a single source, rather than an
   // array of sources
-  // also doesn't allow sortBy filtering yet, as some
-  // sources don't support all types of filtering
-  const { source } = request.query;
+  const { source, sortBy } = request.query;
+  console.log(sortBy);
 
   const search = `https://newsapi.org/v1/articles?apiKey=${process.env.NEWS_KEY}&source=${source}`;
 
-  axios.get(search)
-    .then((newsResponse) => {
-      const articles = newsResponse.data.articles.map((article) => {
-        const newArticle = article;
-        newArticle.source = source;
-        return newArticle;
-      });
-      request.articles = articles;
-      next();
-    })
-    .catch((err) => {
-      console.log(err);
-      response.status(500);
-      response.end();
+  getArticles(search, sortBy, (newsData) => {
+    const articles = newsData.articles.map((article) => {
+      const newArticle = article;
+      newArticle.source = source;
+      return newArticle;
     });
+    request.articles = articles;
+    next();
+  }, (err) => {
+    console.log(err);
+    response.status(500).send('Error--request can\'t be processed.');
+  });
 };
 
 export default searchArticles;


### PR DESCRIPTION
This branch does a bunch:

1. Refactored the api calls into 2 separate functions--a helper for all api calls and a searchArticles function alone.

2. Refactored the api calls to take advantage of the new v2 endpoint /everything. We can now search by topic, with a sortBy filter, and with a single source. I still need to see what a request with multiple sources looks like before I can add that, but the new endpoint fixes the need for an unknown number of chained calls.

3. Add new dummy data for the front-end folks to play around with. 