### PR TITLE
(refactor) update topics components tests to use shallow

### DIFF
--- a/test/client/topicsListSpec.js
+++ b/test/client/topicsListSpec.js
@@ -10,18 +10,18 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('<TopicsList />', function () {
   it('contains a <TopicsListItem /> component', function() {
     const topics = ['politics'];
-    const wrapper = mount(<TopicsList topics={topics} />);
+    const wrapper = shallow(<TopicsList topics={topics} />);
     expect(wrapper.find(TopicsListItem).length).toEqual(1);
   });
 
   it('doesn\'t render <TopicsListItem /> component if no topics are passed in', function() {
-    const wrapper = mount(<TopicsList />);
+    const wrapper = shallow(<TopicsList />);
     expect(wrapper.find(TopicsListItem).length).toEqual(0);
   });
 
   it('contains a <TopicsListItem /> component that dynamically renders topics', function() {
     const topics = ['politics', 'art'];
-    const wrapper = mount(<TopicsList topics={topics} />);
+    const wrapper = shallow(<TopicsList topics={topics} />);
     expect(wrapper.find(TopicsListItem).length).toEqual(2);
   });
 });

--- a/test/client/topicsSearchSpec.js
+++ b/test/client/topicsSearchSpec.js
@@ -2,24 +2,18 @@ import React from 'react';
 import Enzyme, { mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-import App from '../../app/components/App';
-import Header from '../../app/components/Header';
-import NewsList from '../../app/components/NewsList';
-import Topics from '../../app/components/Topics';
-import TopicsList from '../../app/components/TopicsList';
-import TopicsListItem from '../../app/components/TopicsListItem';
 import TopicsSearch from '../../app/components/TopicsSearch';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('<TopicsSearch />', function () {
   it('contains an onSearch function', function() {
-    const wrapper = mount(<TopicsSearch />);
+    const wrapper = shallow(<TopicsSearch />);
     expect(wrapper.props().onSearch).toBe.defined;
   });
 
   it('contains an onSearch function', function() {
-    const wrapper = mount(<TopicsSearch />);
+    const wrapper = shallow(<TopicsSearch />);
     expect(wrapper.props().handleBarChange).toBe.defined;
   });
 });

--- a/test/client/topicsSpec.js
+++ b/test/client/topicsSpec.js
@@ -10,12 +10,12 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('<Topics />', function () {
   it('contains a <TopicsList /> component', function() {
-    const wrapper = mount(<Topics />);
+    const wrapper = shallow(<Topics />);
     expect(wrapper.find(TopicsList).length).toEqual(1);
   });
 
   it('contains a <TopicsSearch /> component', function() {
-    const wrapper = mount(<Topics />);
+    const wrapper = shallow(<Topics />);
     expect(wrapper.find(TopicsSearch).length).toEqual(1);
   });
 });


### PR DESCRIPTION
Made a quick change to the topics components' tests so that they use shallow() instead of mount() at Danny's suggestion. According to the documentation, using mount() actually renders to the DOM, so tests can conflict with each other if you don't unmount() after. Mounting is only needed if you're testing lifecycle methods, otherwise shallow() works.

Tests still pass with the change.