### PR TITLE
Feat/font

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,7 @@
 import { BrowserRouter } from 'react-router-dom';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import 'typeface-roboto';
 import './public/assets/styles.css';
 
 import App from './components/App';

--- a/app/public/assets/styles.css
+++ b/app/public/assets/styles.css
@@ -1,6 +1,10 @@
 /* ------------------ */
 /* CUSTOM CSS STYLING */
 /* ------------------ */
+body {
+  font-family: Roboto, Arial, sans-serif;
+}
+
 .header {
   border: 1px solid black;
   padding: 10px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3426,6 +3426,15 @@
         "object-assign": "4.1.1"
       }
     },
+    "file-loader": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.5.tgz",
+      "integrity": "sha512-RzGHDatcVNpGISTvCpfUfOGpYuSR7HSsSg87ki+wF6rw1Hm0RALPTiAdsxAq1UwLf0RRhbe22/eHK6nhXspiOQ==",
+      "requires": {
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0"
+      }
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9519,6 +9519,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typeface-roboto": {
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/typeface-roboto/-/typeface-roboto-0.0.45.tgz",
+      "integrity": "sha512-hf9xzwtRqlRDjUU0SjunFDbfBHEqGNXap2sW0V4CHfQ+czoy+mTMBylQCGKw+Cnc8jlC/cRinj6lFSE57f4wIg=="
+    },
     "ua-parser-js": {
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^16.1.1",
     "react-router-dom": "^4.2.2",
     "style-loader": "^0.19.0",
+    "typeface-roboto": "0.0.45",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.4"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "css-loader": "^0.28.7",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
+    "file-loader": "^1.1.5",
     "html-webpack-plugin": "^2.30.1",
     "material-ui": "^1.0.0-beta.21",
     "mongoose": "^4.13.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,13 @@ module.exports = {
         loader: 'style-loader!css-loader',
         include: path.join(__dirname, 'app/public/assets/styles.css'),
       },
+      {
+        test: /\.(ttf|eot|woff|woff2)$/,
+        loader: 'file-loader',
+        options: {
+          name: 'fonts/[name].[ext]',
+        },
+      },
     ],
   },
   plugins: [


### PR DESCRIPTION
Updates npm modules and webpack to allow custom fonts. I installed Roboto because that's what Material UI is based off of, but we can update that at any time by installing a different font and changing the CSS file.