### PR TITLE
Test/req intercepts

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -1,7 +1,8 @@
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import React from 'react';
 
-import HomeWithSearch from './HomeWithSearch';
+import search from './helpers/search';
+import Home from './Home';
 import Login from './Login';
 import NotFound from './NotFound';
 
@@ -19,7 +20,7 @@ class App extends React.Component {
           <Route
             exact
             path="/"
-            component={HomeWithSearch}
+            render={() => <Home search={search} />}
           />
           <Route
             path="/login"

--- a/app/components/App.js
+++ b/app/components/App.js
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import React from 'react';
 
-import HomeWithSearch from './Home';
+import HomeWithSearch from './HomeWithSearch';
 import Login from './Login';
 import NotFound from './NotFound';
 

--- a/app/components/App.js
+++ b/app/components/App.js
@@ -1,10 +1,9 @@
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import React from 'react';
 
-import Home from './Home';
+import HomeWithSearch from './Home';
 import Login from './Login';
 import NotFound from './NotFound';
-
 
 class App extends React.Component {
   constructor(props) {
@@ -20,7 +19,7 @@ class App extends React.Component {
           <Route
             exact
             path="/"
-            component={Home}
+            component={HomeWithSearch}
           />
           <Route
             path="/login"

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -6,8 +6,8 @@ import NewsList from './NewsList';
 import Header from './Header';
 
 class Home extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       mostPopular: true,
       articles: [],

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import axios from 'axios';
 import Topics from './Topics';
 import AddSource from './AddSource';
 import SelectedSources from './SelectedSources';
 import NewsList from './NewsList';
 import Header from './Header';
-import search from './helpers/search';
 
 class Home extends React.Component {
   constructor() {

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -7,10 +7,6 @@ import NewsList from './NewsList';
 import Header from './Header';
 import search from './helpers/search';
 
-const HomeWithSearch = () => (
-  <Home search={search} />
-);
-
 class Home extends React.Component {
   constructor() {
     super();
@@ -126,4 +122,4 @@ class Home extends React.Component {
   }
 }
 
-export default HomeWithSearch;
+export default Home;

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -5,7 +5,11 @@ import AddSource from './AddSource';
 import SelectedSources from './SelectedSources';
 import NewsList from './NewsList';
 import Header from './Header';
+import search from './helpers/search';
 
+const HomeWithSearch = () => (
+  <Home search={search} />
+);
 
 class Home extends React.Component {
   constructor() {
@@ -81,17 +85,15 @@ class Home extends React.Component {
   }
 
   getArticles(options) {
-    axios
-      .get('/articles', {
-        params: options,
-      })
-      .then((newsArticles) => {
-        console.log('returned articles: ', newsArticles);
-        this.setState({ articles: newsArticles.data });
-      })
-      .catch((error) => {
-        console.log('error: ', error);
-      });
+    const renderArticles = this.renderArticles.bind(this);
+
+    this.props.search(options, (newsArticles) => {
+      renderArticles(newsArticles);
+    });
+  }
+
+  renderArticles(newsArticles) {
+    this.setState({ articles: newsArticles });
   }
 
   render() {
@@ -124,4 +126,4 @@ class Home extends React.Component {
   }
 }
 
-export default Home;
+export default HomeWithSearch;

--- a/app/components/HomeWithSearch.js
+++ b/app/components/HomeWithSearch.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import search from './helpers/search';
-import Home from './Home';
-
-const HomeWithSearch = () => (
-  <Home search={search} />
-);
-
-export default HomeWithSearch;

--- a/app/components/HomeWithSearch.js
+++ b/app/components/HomeWithSearch.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import search from './helpers/search';
+import Home from './Home';
+
+const HomeWithSearch = () => (
+  <Home search={search} />
+);
+
+export default HomeWithSearch;

--- a/app/components/helpers/search.js
+++ b/app/components/helpers/search.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const search = (options, successCallback) => {
+  axios
+    .get('/articles', {
+      params: options,
+    })
+    .then((newsArticles) => {
+      console.log('returned articles: ', newsArticles);
+      successCallback(newsArticles.data);
+      // this.setState({ articles: newsArticles.data });
+    })
+    .catch((error) => {
+      console.log('error: ', error);
+    });
+};
+
+export default search;

--- a/test/client/appSpec.js
+++ b/test/client/appSpec.js
@@ -9,7 +9,7 @@ import Topics from '../../app/components/Topics';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-describe('<App />', function () {
+xdescribe('<App />', function () {
   it('should have onReferchClick function defined', function () {
     const wrapper = shallow(<App />);
     expect(wrapper.props().onRefreshClick).toBe.defined;
@@ -30,25 +30,25 @@ describe('<App />', function () {
     expect(wrapper.props().onTopicSearch).toBe.defined;
   });
 
-  it('should have an initial mostPopular state of true', function() {
+  xit('should have an initial mostPopular state of true', function() {
     const wrapper = mount(<App />);
     expect(wrapper.state().mostPopular).toBe(true);
     unmount(<App />);
   });
 
-  it('contains a <Header/> component', function() {
+  xit('contains a <Header/> component', function() {
     const wrapper = mount(<App />);
     expect(wrapper.find(Header).length).toEqual(1);
     unmount(<App />);
   });
 
-  it('contains a <NewsList/> component', function() {
+  xit('contains a <NewsList/> component', function() {
     const wrapper = mount(<App />);
     expect(wrapper.find(NewsList).length).toEqual(1);
     unmount(<App />);
   });
 
-  it('contains a <Topics/> component', function() {
+  xit('contains a <Topics/> component', function() {
     const wrapper = mount(<App />);
     expect(wrapper.find(Topics).length).toEqual(1);
     unmount(<App />);

--- a/test/client/appSpec.js
+++ b/test/client/appSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Enzyme, { mount, shallow } from 'enzyme';
+import Enzyme, { mount, shallow, unmount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import App from '../../app/components/App';
@@ -33,20 +33,24 @@ describe('<App />', function () {
   it('should have an initial mostPopular state of true', function() {
     const wrapper = mount(<App />);
     expect(wrapper.state().mostPopular).toBe(true);
+    unmount(<App />);
   });
 
   it('contains a <Header/> component', function() {
     const wrapper = mount(<App />);
     expect(wrapper.find(Header).length).toEqual(1);
+    unmount(<App />);
   });
 
   it('contains a <NewsList/> component', function() {
     const wrapper = mount(<App />);
     expect(wrapper.find(NewsList).length).toEqual(1);
+    unmount(<App />);
   });
 
   it('contains a <Topics/> component', function() {
     const wrapper = mount(<App />);
     expect(wrapper.find(Topics).length).toEqual(1);
+    unmount(<App />);
   });
 });

--- a/test/client/appSpec.js
+++ b/test/client/appSpec.js
@@ -10,47 +10,5 @@ import Topics from '../../app/components/Topics';
 Enzyme.configure({ adapter: new Adapter() });
 
 xdescribe('<App />', function () {
-  it('should have onReferchClick function defined', function () {
-    const wrapper = shallow(<App />);
-    expect(wrapper.props().onRefreshClick).toBe.defined;
-  });
-
-  it('should have onToggleClick function defined', function() {
-    const wrapper = shallow(<App />);
-    expect(wrapper.props().onToggleClick).toBe.defined;
-  });
-
-  it('should have onTopicRemoval function defined', function() {
-    const wrapper = shallow(<App />);
-    expect(wrapper.props().onTopicRemoval).toBe.defined;
-  });
-
-  it('should have onTopicSearch function defined', function() {
-    const wrapper = shallow(<App />);
-    expect(wrapper.props().onTopicSearch).toBe.defined;
-  });
-
-  xit('should have an initial mostPopular state of true', function() {
-    const wrapper = mount(<App />);
-    expect(wrapper.state().mostPopular).toBe(true);
-    unmount(<App />);
-  });
-
-  xit('contains a <Header/> component', function() {
-    const wrapper = mount(<App />);
-    expect(wrapper.find(Header).length).toEqual(1);
-    unmount(<App />);
-  });
-
-  xit('contains a <NewsList/> component', function() {
-    const wrapper = mount(<App />);
-    expect(wrapper.find(NewsList).length).toEqual(1);
-    unmount(<App />);
-  });
-
-  xit('contains a <Topics/> component', function() {
-    const wrapper = mount(<App />);
-    expect(wrapper.find(Topics).length).toEqual(1);
-    unmount(<App />);
-  });
+  // add <App> tests here
 });

--- a/test/client/homeSpec.js
+++ b/test/client/homeSpec.js
@@ -36,6 +36,21 @@ describe('<Home />', function () {
     expect(wrapper.props().onTopicSearch).toBe.defined;
   });
 
+  it('should have onAddSource function defined', function() {
+    const wrapper = shallow(<Home search={dummySearch} />);
+    expect(wrapper.props().onAddSource).toBe.defined;
+  });
+
+  it('should have getArticles function defined', function() {
+    const wrapper = shallow(<Home search={dummySearch} />);
+    expect(wrapper.props().getArticles).toBe.defined;
+  });
+
+  it('should have renderArticles function defined', function() {
+    const wrapper = shallow(<Home search={dummySearch} />);
+    expect(wrapper.props().renderArticles).toBe.defined;
+  });
+
   it('should have an initial mostPopular state of true', function() {
     const wrapper = shallow(<Home search={dummySearch} />);
     expect(wrapper.state().mostPopular).toBe(true);

--- a/test/client/homeSpec.js
+++ b/test/client/homeSpec.js
@@ -6,47 +6,53 @@ import Home from '../../app/components/Home';
 import Header from '../../app/components/Header';
 import NewsList from '../../app/components/NewsList';
 import Topics from '../../app/components/Topics';
+import v2DummyArticles from '../../app/dummy-data/articles_v2';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('<Home />', function () {
+  const dummySearch = (options, successCallback) => {
+    const { articles } = v2DummyArticles;
+    successCallback(articles);
+  };
+
   it('should have onRefreshClick function defined', function () {
-    const wrapper = shallow(<Home />);
+    const wrapper = shallow(<Home search={dummySearch} />);
     expect(wrapper.props().onRefreshClick).toBe.defined;
   });
 
   it('should have onToggleClick function defined', function() {
-    const wrapper = shallow(<Home />);
+    const wrapper = shallow(<Home search={dummySearch} />);
     expect(wrapper.props().onToggleClick).toBe.defined;
   });
 
-  xit('should have onTopicRemoval function defined', function() {
-    const wrapper = shallow(<Home />);
+  it('should have onTopicRemoval function defined', function() {
+    const wrapper = shallow(<Home search={dummySearch} />);
     expect(wrapper.props().onTopicRemoval).toBe.defined;
   });
 
-  xit('should have onTopicSearch function defined', function() {
-    const wrapper = shallow(<Home />);
+  it('should have onTopicSearch function defined', function() {
+    const wrapper = shallow(<Home search={dummySearch} />);
     expect(wrapper.props().onTopicSearch).toBe.defined;
   });
 
-  xit('should have an initial mostPopular state of true', function() {
-    const wrapper = mount(<Home />);
+  it('should have an initial mostPopular state of true', function() {
+    const wrapper = shallow(<Home search={dummySearch} />);
     expect(wrapper.state().mostPopular).toBe(true);
   });
 
-  xit('contains a <Header/> component', function() {
-    const wrapper = mount(<Home />);
+  it('contains a <Header/> component', function() {
+    const wrapper = shallow(<Home search={dummySearch} />);
     expect(wrapper.find(Header).length).toEqual(1);
   });
 
-  xit('contains a <NewsList/> component', function() {
-    const wrapper = mount(<Home />);
+  it('contains a <NewsList/> component', function() {
+    const wrapper = shallow(<Home search={dummySearch} />);
     expect(wrapper.find(NewsList).length).toEqual(1);
   });
 
-  xit('contains a <Topics/> component', function() {
-    const wrapper = mount(<Home />);
+  it('contains a <Topics/> component', function() {
+    const wrapper = shallow(<Home search={dummySearch} />);
     expect(wrapper.find(Topics).length).toEqual(1);
   });
 });

--- a/test/client/homeSpec.js
+++ b/test/client/homeSpec.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import Enzyme, { mount, shallow, unmount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+import Home from '../../app/components/Home';
+import Header from '../../app/components/Header';
+import NewsList from '../../app/components/NewsList';
+import Topics from '../../app/components/Topics';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('<Home />', function () {
+  it('should have onRefreshClick function defined', function () {
+    const wrapper = shallow(<Home />);
+    expect(wrapper.props().onRefreshClick).toBe.defined;
+  });
+
+  it('should have onToggleClick function defined', function() {
+    const wrapper = shallow(<Home />);
+    expect(wrapper.props().onToggleClick).toBe.defined;
+  });
+
+  xit('should have onTopicRemoval function defined', function() {
+    const wrapper = shallow(<Home />);
+    expect(wrapper.props().onTopicRemoval).toBe.defined;
+  });
+
+  xit('should have onTopicSearch function defined', function() {
+    const wrapper = shallow(<Home />);
+    expect(wrapper.props().onTopicSearch).toBe.defined;
+  });
+
+  xit('should have an initial mostPopular state of true', function() {
+    const wrapper = mount(<Home />);
+    expect(wrapper.state().mostPopular).toBe(true);
+  });
+
+  xit('contains a <Header/> component', function() {
+    const wrapper = mount(<Home />);
+    expect(wrapper.find(Header).length).toEqual(1);
+  });
+
+  xit('contains a <NewsList/> component', function() {
+    const wrapper = mount(<Home />);
+    expect(wrapper.find(NewsList).length).toEqual(1);
+  });
+
+  xit('contains a <Topics/> component', function() {
+    const wrapper = mount(<Home />);
+    expect(wrapper.find(Topics).length).toEqual(1);
+  });
+});


### PR DESCRIPTION
This pull request fixes the 404 errors we were getting with our client-side tests. To do this, I had to refactor some things in the App and Home components.

I couldn't figure out a way to really intercept/prevent ajax requests from our getArticles search that's called with componentDidMount on Home. The solution I thought I had didn't end up working once Patrick's code got merged. I looked at the old recastly project tests and the way they fixed that was to pass in the search function as a prop, so that in the test you can pass in a stub instead.

To accomplish that with React Router, I had to create an intermediate component (HomeWithSearch) that we pass to the Router in App, since we can't pass down props there. I then passed in a search helper function as a prop to Home in the HomeWithSearch component. From there, I could substitute out the search function in the tests and simply return our dummy data instead.

It turns out that we didn't need a full mount() for any of our tests, so I changed them to shallow() and added a few more to reflect all of our current methods on Home.