### PR TITLE
(fix) update map on SelectedSources component

### DIFF
--- a/app/components/SelectedSources.js
+++ b/app/components/SelectedSources.js
@@ -2,9 +2,9 @@ import React from 'react';
 import SourceItem from './SourceItem';
 
 export default (props) => {
-  const sources = props.selectedSources.map((source) => {
-    return <SourceItem source={source} />;
-  });
+  const sources = props.selectedSources.map(source => (
+    <SourceItem key={source} source={source} />
+  ));
   return (
     <div className="selectedSourcesContainer">
       {sources}


### PR DESCRIPTION
Fixes 2 errors:

linting error around map formatting

adds a key to the SourceItem component, so React won't shout warnings at us