### PR TITLE
(refactor) combined unnecessary extra function

### DIFF
--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -79,15 +79,9 @@ class Home extends React.Component {
   }
 
   getArticles(options) {
-    const renderArticles = this.renderArticles.bind(this);
-
     this.props.search(options, (newsArticles) => {
-      renderArticles(newsArticles);
+      this.setState({ articles: newsArticles });
     });
-  }
-
-  renderArticles(newsArticles) {
-    this.setState({ articles: newsArticles });
   }
 
   render() {


### PR DESCRIPTION
factored out the `renderArticles()` function and put it's code directly into `getArticles()`