### PR TITLE
Bug/load articles

### DIFF
--- a/app/server/middleware/searchArticles.js
+++ b/app/server/middleware/searchArticles.js
@@ -15,7 +15,9 @@ const searchArticles = (request, response, next) => {
   }
   if (selectedSources) {
     const formattedSource = selectedSources.map((source) => {
-      return JSON.parse(source).id;
+      const parsedSource = JSON.parse(source);
+      console.log(parsedSource);
+      return parsedSource.id;
     }).join(',');
     url += `&sources=${formattedSource}`;
   } else if (!selectedSources && !topics) {

--- a/app/server/middleware/searchArticles.js
+++ b/app/server/middleware/searchArticles.js
@@ -16,7 +16,6 @@ const searchArticles = (request, response, next) => {
   if (selectedSources) {
     const formattedSource = selectedSources.map((source) => {
       const parsedSource = JSON.parse(source);
-      console.log(parsedSource);
       return parsedSource.id;
     }).join(',');
     url += `&sources=${formattedSource}`;


### PR DESCRIPTION
Heroku for some reason didn't like having the `return JSON.parse(source).id` expression on a single line--it was causing errors on their server that didn't exist in the local environment. Breaking it into 2 lines seems to fix it.

See [Trello Ticket](https://trello.com/c/RBCSEeUY) for picture of Heroku logs of error.